### PR TITLE
docs: clarify timeline placement and scrollbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@ See [this page](https://www.historicaltechtree.com/) for an alternative, signifi
 
 The code is organized as follows:
 - [`index.html`](index.html) - HTML structure
-- [`style.css`](style.css) - Styling and layout  
-- [`script.js`](script.js) - Timeline class and interactions
+- [`style.css`](style.css) - Styling and layout
+- [`script.js`](script.js) - Timeline class, deterministic date-based placement, and interactions
 - [`scroll.js`](scroll.js) - Dynamic scroll speed scaling for adaptive navigation
-- [`scrollbar.js`](scrollbar.js) - Custom scrollbar with chronological position mapping
 - [`data.js`](data.js) - All timeline data and configuration
 
 It features specialized navigation to smooth out the historical experience:
-- Events are spread on screen to avoid overlap
+- Deterministic date-based placement with index-derived offsets (no collision pass)
 - Dynamic speed scaling accelerates through empty millennia for consistent navigation
-- Custom scrollbar position maps to historical dates (not pixels) with event indicators and click-to-jump navigation
+- Native scrollbar overlays markers mapping to historical dates with click-to-jump navigation
 
 ## Usage
 
@@ -40,10 +39,3 @@ It features specialized navigation to smooth out the historical experience:
 ## TODO
 
 * double-check all links
-
-**placement:**
-if i were to redo the placement algorithm, i would have it be placement(time) + event_size(including side margings)*nb_events_before/2 (division to take events below us into account; but we might want to use integer division such that we only count events on our side of the line)
-
-event would be spread a bit more, and still stretch chronology, but their placement would be predictable, regular, and have a limited impact on the scrolling and dating of things: placing something as a function of its date would be instantly easier.
-
-cutting the need for our custom scrollbar logic, for adjustments to title placements, for our last event being further in the future than we might want, etc


### PR DESCRIPTION
## Summary
- document deterministic date-index placement in the Code and navigation sections
- mention overlay markers on the native scrollbar instead of custom scrollbar
- remove outdated placement TODO notes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689638b338d88326a1cb8efd9e37d669